### PR TITLE
Update plugin for Minecraft 1.20.1 compatibility and improve SkyBlock support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <name>B_s_BeePost</name>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.20.6-R0.1-SNAPSHOT</version>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/biraw/online/b_s_BeePost/B_s_BeePost.java
+++ b/src/main/java/biraw/online/b_s_BeePost/B_s_BeePost.java
@@ -84,8 +84,9 @@ public final class B_s_BeePost extends JavaPlugin {
         this.getLogger().info(" ");
         this.getLogger().info("O=========================================================O");
         this.getLogger().info("      The B's BeePost plugin has loaded successfully!");
-        this.getLogger().info("         This is B's BeePost for Minecraft 1.20.5+");
+        this.getLogger().info("         This is B's BeePost for Minecraft 1.20.1");
         this.getLogger().info("                       Author: BiRaw");
+        this.getLogger().info("                         Edit: Zao");
         this.getLogger().info("         Discord: https://discord.gg/XwFqu7uahX :>");
         this.getLogger().info("O=========================================================O");
         this.getLogger().info(" ");

--- a/src/main/java/biraw/online/b_s_BeePost/Bee/BeeAI.java
+++ b/src/main/java/biraw/online/b_s_BeePost/Bee/BeeAI.java
@@ -135,7 +135,7 @@ public class BeeAI {
                 Player receiver = (Player) offlineReceiver; // Just mold the receiver to a Player for easier usage
 
                 // If the bee gets too far from the owner, it disappears
-                if (bee.getWorld() == receiver.getWorld() && bee.getLocation().distance(receiver.getLocation())>=80)
+                if (bee.getWorld() == receiver.getWorld() && bee.getLocation().distance(receiver.getLocation())>=200)
                 {
                     receiver.sendMessage(I18N.translate("POST_BEE_DISAPPEARED"));
                     this.cancel();

--- a/src/main/java/biraw/online/b_s_BeePost/Utilities.java
+++ b/src/main/java/biraw/online/b_s_BeePost/Utilities.java
@@ -6,7 +6,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 import java.util.Random;
 
-
 public class Utilities {
 
     public static void spawnBeeDisappearParticles(Location center){
@@ -26,18 +25,18 @@ public class Utilities {
 
             // Get the final position
             Location particleLocation = center.clone().add(particleOffset);
-
-            // Spawn the particle
-            center.getWorld().spawnParticle(Particle.WHITE_SMOKE, particleLocation, 1, 0, 0, 0, 0.1);
+            // ZAO EDIT - Spawn the particle (compatibile con 1.20.1)
+            center.getWorld().spawnParticle(Particle.SMOKE_NORMAL, particleLocation, 1, 0, 0, 0, 0.1);
         }
     }
 
-    public static void spawnParticleForBee(Location location,Color color){
+    public static void spawnParticleForBee(Location location, Color color){
+        // ZAO EDIT - REDSTONE its the correct name for the dust particles in 1.20.1
         Particle.DustOptions option = new Particle.DustOptions(color, 2f);
-        location.getWorld().spawnParticle(Particle.DUST, location.add(0.0,1.0,0.0), 5, option);
+        location.getWorld().spawnParticle(Particle.REDSTONE, location.add(0.0, 1.0, 0.0), 5, option);
     }
 
-    public static void swapHands(Player player) { // This is to prevent the player from opening the book, if they have multiple in hand
+    public static void swapHands(Player player) {
         ItemStack mainHandItem = player.getInventory().getItemInMainHand();
         ItemStack offHandItem = player.getInventory().getItemInOffHand();
 


### PR DESCRIPTION
This pull request updates the plugin for full compatibility with Minecraft version 1.20.1. The main changes include:

Updated Java version target and Maven compiler settings to support Java 17 (required by Minecraft 1.20.1).

Replaced deprecated or renamed Bukkit particle enums (WHITE_SMOKE to SMOKE_NORMAL, DUST to REDSTONE) to fix compilation errors.

Adjusted bee spawn location logic to better fit small SkyBlock islands, reducing spawn radius and increasing vertical offset.

Modified bee distance tolerance checks to prevent bees from disappearing too early in limited space environments. (skyblocks islands)

General code cleanup and improved scheduling for bee tasks.

These changes aim to preserve the original plugin behavior while enhancing its functionality on SkyBlock servers and Minecraft 1.20.1 environments.